### PR TITLE
システムテスト(user, user_sessions)作成#20

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,10 +8,10 @@ class UserSessionsController < ApplicationController
 
     if @user
 
-      redirect_back_or_to root_path, success: 'ログインしました'
+      redirect_back_or_to root_path, success: t('.success')
     else
-      flash.now[:danger] = 'ログインに失敗しました'
-      render :new
+      flash.now[:danger] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,9 +7,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, success: 'ユーザー登録が完了しました'
+      redirect_to login_path, success: t('.success')
     else
-      render :new
+      flash.now[:danger] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,3 +1,3 @@
 <p>ここはログイン前のヘッダーです</p>
-<%= link_to 'ユーザー新規登録', new_user_path %>
-<%= link_to 'ログイン', login_path %>
+<%= link_to (t 'defaults.register'), new_user_path %>
+<%= link_to (t 'defaults.login'), login_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,3 +1,3 @@
 <p>ここはログインした後のヘッダーです</p>
 <%= link_to 'top', root_path %>
-<%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete } %>
+<%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete } %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,14 +1,14 @@
 <div class="container">
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ログイン</h1>
+      <h1><%= t '.title' %></h1>
       <%= form_with url: login_path, local: true do |form| %>
         <div class="form-group">
-          <%= form.label :email, "email" %>
+          <%= form.label :email, User.human_attribute_name(:email) %>
           <%= form.text_field :email, class: "form-control", id: "email" %>
         </div>
         <div class="form-group">
-          <%= form.label :password, "password" %>
+          <%= form.label :password, User.human_attribute_name(:password) %>
           <%= form.password_field :password, class: "form-control", id: "password" %>
         </div>
         <div class="actions">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,7 +19,7 @@
           <%= form.label :password_confirmation %>
           <%= form.password_field :password_confirmation, class: "form-control" %>
         </div>
-        <%= form.submit "登録する", class:'btn btn-primary' %>
+        <%= form.submit ( t 'defaults.register'), class:'btn btn-primary' %>
       <% end %>
       <div class='text-center'>
         <%= link_to "topページ", root_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-      <h1>ユーザー新規登録</h1>
+      <h1><%= t '.title' %></h1>
       <%= form_with model: @user, local: true do |form| %>
         <div class="form-group">
          <%= form.label :name %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,28 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      
+    attributes: 
+      user:
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'
+        name: '名前'
+        avatar: 'アバター'    
+        role: '権限'
+        created_at: '作成日時'
+      # post作成後に対応させる
+      # board:
+      #   title: 'タイトル'
+      #   body: '本文'
+      #   board_image: 'サムネイル'
+      #   full_name: '作成者'
+      #   created_at: '作成日時'
+      # comment:
+      #   body: 'コメント'
+  # enums:
+  #   user:
+  #     role: 
+  #         general: '一般'
+  #         admin: '管理者'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,101 @@
+ja:
+  defaults:
+    login: 'ログイン'
+    register: '登録'
+    logout: 'ログアウト'
+    post: '投稿'
+    search_word: '検索ワード'
+    edit: '編集'
+    show: '詳細'
+    delete: '削除'
+    password_reset: 'パスワードリセット'
+    unspecified: '指定なし'
+    message:
+      require_login: 'ログインしてください'
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成できませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新できませんでした"
+      deleted: "%{item}を削除しました"
+      delete_confirm: '削除しますか？'
+      not_authorized: '権限がありません'
+      
+  users:
+    new:
+      title: 'ユーザー登録'
+      to_login_page: 'ログインページへ'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
+
+  user_sessions:
+    new:
+      title: 'ログイン'
+      to_register_page: '登録ページへ'
+      password_forget: 'パスワードをお忘れの方はこちらへ'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'
+  # boards:
+  #   index:
+  #     title: '掲示板一覧'
+  #     no_result: '掲示板がありません。'
+  #   new:
+  #     title: '掲示板作成'
+  #   show:
+  #     title: '掲示板詳細'
+  #   edit:
+  #     title: '掲示板編集'
+  #   bookmarks:
+  #     title: 'ブックマーク一覧'
+  #     no_result: 'ブックマーク中の掲示板がありません'
+  # bookmarks:
+  #   create:
+  #     success: 'ブックマークしました'
+  #   destroy:
+  #     success: 'ブックマークを外しました'
+  # profiles:
+  #   show:
+  #     title: 'プロフィール'
+  #   edit:
+  #     title: 'プロフィール編集'
+  # password_resets: 
+  #   new:
+  #     title: 'パスワードリセット申請'
+  #     submit: '送信'
+  #   edit:
+  #     title: 'パスワードリセット'
+  #   create:
+  #     success: 'パスワードリセット手順を送信しました'
+  #   update:
+  #     success: 'パスワードを変更しました'
+  #     fail: 'パスワードの変更に失敗しました'
+  
+  # admin:
+  #   user_sessions:
+  #     new: 
+  #       title: 'ログイン'
+  #     create:
+  #       success: 'ログインしました'
+  #       fail: 'ログインに失敗しました'
+  #     destroy:
+  #       success: 'ログアウトしました'
+  #   dashboards:
+  #     index:
+  #       title: 'ダッシュボード'
+  #   users:
+  #     index:
+  #       title: 'ユーザー一覧'
+  #     show: 
+  #       title: 'ユーザー詳細'
+  #     edit: 
+  #       title: 'ユーザー編集'
+  #   boards:
+  #     index:
+  #       title: '掲示板一覧'
+  #     show:
+  #       title: '掲示板詳細'
+  #     edit:
+  #       title: '掲示板編集'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe User, type: :model do
     it 'passwordとpassword_confirmationが一致していない場合、無効' do
       user = build(:user, password_confirmation: 'aaaaaaa')
       user.valid?
-      expect(user.errors[:password_confirmation]).to eq ['とPasswordの入力が一致しません']
+      expect(user.errors[:password_confirmation]).to eq ['とパスワードの入力が一致しません']
     end
   end
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,7 +1,8 @@
 module LoginMacros
-  def login(user)
-    fill_in 'email', with: user.email
-    fill_in 'password', with: 'password'
+  def login_as(user)
+    visit login_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
     click_button 'ログイン'
   end
 end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+
+end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,5 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe "UserSessions", type: :system do
-  
+  let(:user) { create(:user) }
+
+  describe '通常のログインログアウト' do
+    context '正常系' do
+      it 'ログインができる' do
+        visit login_path
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード',	with: 'password'
+        click_button 'ログイン'
+        expect(page).to  have_content 'ログインしました'
+        # posts機能実装後コメントアウトを外す↓
+        # expect(current_path).to eq posts_path
+      end
+
+      it 'ログアウトができる' do
+        login_as(user)
+        click_link 'ログアウト'
+        expect(page).to  have_content 'ログアウトしました'
+      end
+    end
+
+    context '異常系' do
+      it 'メールアドレスが未入力の場合、ログインできない' do
+        visit login_path
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード',	with: 'password'
+        click_button 'ログイン'
+        expect(current_path).to eq login_path
+        expect(page).to  have_content 'ログインに失敗しました'
+      end
+
+      it 'パスワードが未入力の場合、ログインできない' do
+        visit login_path
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード',	with: ''
+        click_button 'ログイン'
+        expect(current_path).to eq login_path
+        expect(page).to  have_content 'ログインに失敗しました'
+      end
+    end
+  end
+
+  describe 'ゲストログイン' do
+    # 後で書きます
+  end
 end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "UserSessions", type: :system do
+RSpec.describe 'UserSessions', type: :system do
   let(:user) { create(:user) }
 
   describe '通常のログインログアウト' do
@@ -10,7 +10,7 @@ RSpec.describe "UserSessions", type: :system do
         fill_in 'メールアドレス', with: user.email
         fill_in 'パスワード',	with: 'password'
         click_button 'ログイン'
-        expect(page).to  have_content 'ログインしました'
+        expect(page).to have_content 'ログインしました'
         # posts機能実装後コメントアウトを外す↓
         # expect(current_path).to eq posts_path
       end
@@ -18,7 +18,7 @@ RSpec.describe "UserSessions", type: :system do
       it 'ログアウトができる' do
         login_as(user)
         click_link 'ログアウト'
-        expect(page).to  have_content 'ログアウトしました'
+        expect(page).to have_content 'ログアウトしました'
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe "UserSessions", type: :system do
         fill_in 'パスワード',	with: 'password'
         click_button 'ログイン'
         expect(current_path).to eq login_path
-        expect(page).to  have_content 'ログインに失敗しました'
+        expect(page).to have_content 'ログインに失敗しました'
       end
 
       it 'パスワードが未入力の場合、ログインできない' do
@@ -38,7 +38,7 @@ RSpec.describe "UserSessions", type: :system do
         fill_in 'パスワード',	with: ''
         click_button 'ログイン'
         expect(current_path).to eq login_path
-        expect(page).to  have_content 'ログインに失敗しました'
+        expect(page).to have_content 'ログインに失敗しました'
       end
     end
   end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
 
-
+RSpec.describe "UserSessions", type: :system do
+  
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,5 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  
+  describe 'ユーザーの新規作成' do
+    # 異常系：メールアドレスが重複する場合のためにletで定義しておく
+    let(:existed_user) { create(:user) }
+
+    context '正常系' do
+      it 'ユーザーの新規作成ができる' do
+        visit new_user_path
+        fill_in '名前', with: 'test_name'
+        fill_in 'メールアドレス', with: 'test@example.com'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード確認', with: 'password'
+        expect { click_button '登録' }.to change { User.count }.by(1)
+        expect(current_path).to eq new_user_path
+        expect(page).to have_content('ユーザー登録が完了しました')
+      end
+    end
+
+    context '異常系' do
+      it 'メールアドレスが未入力の場合、新規作成できない' do
+        visit new_user_path
+        fill_in '名前', with: 'test_name'
+        fill_in 'メールアドレス', with: ''
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード確認', with: 'password'
+        expect { click_button '登録' }.to change { User.count }.by(0)
+        expect(current_path).to eq new_user_path
+        expect(page).to have_content('ユーザー登録に失敗しました')
+        # エラーメッセージ実装後コメントアウトを外す↓
+        # expect(page).to have_content('メールアドレスを入力してください')
+      end
+
+      it 'メールアドレスが登録してあり重複する場合、新規作成できない' do
+        visit new_user_path
+        fill_in '名前', with: 'test_name'
+        fill_in 'メールアドレス', with: existed_user.email
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード確認', with: 'password'
+        expect { click_button '登録' }.to change { User.count }.by(0)
+        expect(current_path).to eq new_user_path
+        expect(page).to have_content('ユーザー登録に失敗しました')
+        # エラーメッセージ実装後コメントアウトを外す↓
+        # expect(page).to have_content('メールアドレスはすでに存在します')
+      end
+
+    end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Users", type: :system do
+RSpec.describe 'Users', type: :system do
   describe 'ユーザーの新規作成' do
     # 異常系：メールアドレスが重複する場合のためにletで定義しておく
     let(:existed_user) { create(:user) }
@@ -44,7 +44,6 @@ RSpec.describe "Users", type: :system do
         # エラーメッセージ実装後コメントアウトを外す↓
         # expect(page).to have_content('メールアドレスはすでに存在します')
       end
-
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  
+end


### PR DESCRIPTION
### 内容
・途中#26ブランチを切って翻訳の適用を行い、#27でmergeしました。(5b8484c) (0a513da) (6ec9a10)
・turbo関連で、バリデーション失敗時のrenderでフラッシュメッセージが作動しなかったので、`status: :unprocessable_entity`オプションを使用し適用しました。(2135668)
・user_specとuser_sessions_specテストコードを記述しました。(0b64f4f) (a95acde)

なお、ゲストログイン機能のテストは実装後追記します。(system/user_sessions_spec.rb)


### 確認方法
ローカルテストをパスしたので、下記画像でご確認ください。

### `users_spec`
![image](https://user-images.githubusercontent.com/110599239/220256999-74ce2c6f-3836-455c-96f6-4fc0d9817eb3.png)



### `user_sessions_spec`
![image](https://user-images.githubusercontent.com/110599239/220256920-4345f9d6-ba1b-44ff-accd-cfbcfe38e643.png)


### Issue

#20 
