### PR TITLE
Post投稿一覧機能#25

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem 'dotenv-rails'
 # Password Authentication
 gem 'sorcery'
 
+# seed
+gem 'seed-fu'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,9 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    seed-fu (2.3.9)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -334,6 +337,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
+  seed-fu
   sorcery
   sprockets-rails
   stimulus-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    flash[:danger] = 'ログインしてください'
+    flash[:warning] = t('defaults.message.require_login')
     redirect_to login_path
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,13 @@
+class PostsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def edit
+  end
+
+  def show
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,13 +1,31 @@
 class PostsController < ApplicationController
   def index
+    @posts = Post.all.includes(:user).order(created_at: :desc)
   end
 
   def new
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.new(post_params)
+    if @post.save
+      redirect_to posts_path, success: t('defaults.message.created', item: Post.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.message.not_created', item: Post.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
   end
 
   def show
+  end
+
+
+  private
+  def post_params
+    params.require(:post).permit(:title, :content, :embed_youtube)
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
 
     if @user
 
-      redirect_back_or_to root_path, success: t('.success')
+      redirect_back_or_to posts_path, success: t('.success')
     else
       flash.now[:danger] = t('.fail')
       render :new, status: :unprocessable_entity
@@ -17,6 +17,6 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to root_path, success: 'ログアウトしました', status: :see_other
+    redirect_to root_path, success: t('.success'), status: :see_other
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :body, presence: true, length: { maximum: 65_535 }
+  validates :embed_youtube, length: { maximum: 200 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,6 @@ class Post < ApplicationRecord
   belongs_to :user
 
   validates :title, presence: true, length: { maximum: 255 }
-  validates :body, presence: true, length: { maximum: 65_535 }
+  validates :content, presence: true, length: { maximum: 65_535 }
   validates :embed_youtube, length: { maximum: 200 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 15 }
   validates :email, presence: true, uniqueness: true
+
+  has_many :posts, dependent: :destroy
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,3 +2,4 @@
 <%= post.user.name %>
 <%= l post.created_at, format: :long %>
 <%= post.content %>
+<br>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,4 @@
+<%= post.title %>
+<%= post.user.name %>
+<%= l post.created_at, format: :long %>
+<%= post.content %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Posts#edit</h1>
+<p>Find me in app/views/posts/edit.html.erb</p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Posts#index</h1>
+<p>Find me in app/views/posts/index.html.erb</p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,2 +1,7 @@
 <h1>Posts#index</h1>
-<p>Find me in app/views/posts/index.html.erb</p>
+
+<% if @posts.present? %>
+  <%= render @posts %>
+<% else %>
+  <p><%= t('.no_result') %></p>
+<% end %>  

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Posts#new</h1>
+<p>Find me in app/views/posts/new.html.erb</p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Posts#show</h1>
+<p>Find me in app/views/posts/show.html.erb</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,3 +1,4 @@
 <p>ここはログインした後のヘッダーです</p>
 <%= link_to 'top', root_path %>
 <%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete } %>
+<%= link_to t('posts.index.title'), posts_path %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -38,19 +38,19 @@ ja:
       fail: 'ログインに失敗しました'
     destroy:
       success: 'ログアウトしました'
-  # boards:
-  #   index:
-  #     title: '掲示板一覧'
-  #     no_result: '掲示板がありません。'
-  #   new:
-  #     title: '掲示板作成'
-  #   show:
-  #     title: '掲示板詳細'
-  #   edit:
-  #     title: '掲示板編集'
+  posts:
+    index:
+      title: '投稿一覧'
+      no_result: '投稿がありません。'
+    new:
+      title: '投稿作成'
+    show:
+      title: '投稿詳細'
+    edit:
+      title: '投稿編集'
   #   bookmarks:
   #     title: 'ブックマーク一覧'
-  #     no_result: 'ブックマーク中の掲示板がありません'
+  #     no_result: 'ブックマーク中の投稿がありません'
   # bookmarks:
   #   create:
   #     success: 'ブックマークしました'
@@ -94,8 +94,8 @@ ja:
   #       title: 'ユーザー編集'
   #   boards:
   #     index:
-  #       title: '掲示板一覧'
+  #       title: '投稿一覧'
   #     show:
-  #       title: '掲示板詳細'
+  #       title: '投稿詳細'
   #     edit:
-  #       title: '掲示板編集'
+  #       title: '投稿編集'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+
+  resources :posts, only: %i[index new create]
 end

--- a/db/fixtures/development/posts.rb
+++ b/db/fixtures/development/posts.rb
@@ -1,0 +1,10 @@
+1.upto(20) do |index|
+  Post.seed(
+  :id,
+  {
+    user: User.offset(rand(User.count)).first,
+    title: "title#{index}",
+    content: "content#{index}"
+  }
+  )
+end

--- a/db/fixtures/development/users.rb
+++ b/db/fixtures/development/users.rb
@@ -1,0 +1,13 @@
+1.upto(10) do |user|
+  User.seed(
+    # 基本はidでseed-fuは投下データの同一性を判断する。idは省略可能なので、ユニークなemailで同一性判断をする場合の書き方になる。
+    # 参考:https://qiita.com/punkshiraishi/items/18c80475fcd50d708dc4
+  :email,
+  {
+  name: "test_#{user}",
+  email: "test#{user}@example.com",
+  crypted_password: "password#{user}",
+  salt: "password#{user}"
+  }
+  )
+end

--- a/db/migrate/20230221062416_create_posts.rb
+++ b/db/migrate/20230221062416_create_posts.rb
@@ -1,0 +1,13 @@
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :content, null: false
+      t.string :embed_youtube
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_220_024_106) do
-  create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_062416) do
+  create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.string "embed_youtube"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "posts", "users"
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :post do
+    user { nil }
+    title { "MyString" }
+    content { "MyText" }
+    embed_youtube { "MyString" }
+    image { "MyString" }
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/posts/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/posts/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/posts/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/posts/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/posts/edit.html.erb_spec.rb
+++ b/spec/views/posts/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "posts/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "posts/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/posts/new.html.erb_spec.rb
+++ b/spec/views/posts/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "posts/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "posts/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 内容
・Postテーブルを作成しmigrateしました。また、関連付けとバリデーションも記述しました。
・postsコントローラとルーティングを追加しました。
・初期データとしてgem 'seed-fu'を導入し、UserとPostのseedデータが投下できるようにしました。
・postのindexページに初期データが一覧表示されることをブラウザで確認しました。

なお、postsのmodelテストとsystemテストは別のissueを立てる予定です。

### 確認方法
### `UserとPostの関連付け`
![image](https://user-images.githubusercontent.com/110599239/220343325-5ce04b65-7a44-423e-a7a8-78d890de9ac1.png)


### `/posts`
![image](https://user-images.githubusercontent.com/110599239/220343847-d9b594d8-10bf-48e8-ab7e-2fe4690374d2.png)



### Issue

#25 