### PR TITLE
postにYouTube埋め込み機能を追加 #40

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,4 +4,15 @@ class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :content, presence: true, length: { maximum: 65_535 }
   validates :embed_youtube, length: { maximum: 200 }
+
+  def split_id_from_youtube_url
+    # YoutubeならIDのみ抽出
+    if self.embed_youtube?
+      if self.embed_youtube.include?('youtu.be')
+        embed_youtube.split('/').last
+      elsif self.embed_youtube.include?('youtube.com')
+        embed_youtube.split('=').last
+      end
+    end
+  end
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,6 +2,9 @@
 <%= post.user.name %>
 <%= l post.created_at, format: :long %>
 <%= post.content %>
+<% if post.embed_youtube? %>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/<%= "#{post.split_id_from_youtube_url}" %>" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<% end %>
 <% if current_user.own?(post) %>
   <%= render 'crud_menus', post: post %>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,4 @@
 <h1>Posts#index</h1>
-
 <% if @posts.present? %>
   <%= render @posts %>
 <% else %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,6 +4,9 @@
 <%= @post.user.name %>
 <%= l @post.created_at, format: :long %>
 <%= simple_format(@post.content) %>
+<% if @post.embed_youtube? %>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/<%= "#{@post.split_id_from_youtube_url}" %>" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<% end %>
 
 <!-- ↓編集、削除ボタンはcrud_menuパーシャルにすること。また、fontawesomeを使うこと。current_userでなければbookmark_buttonにすること。-->
 <%= render 'crud_menus', post: @post if current_user.own?(@post) %>


### PR DESCRIPTION
### 内容
・ユーザーが投稿するyoutube埋め込み動画をビューで表示できるようにしました。
・投稿一覧と投稿詳細で閲覧可能としました。
・ユーザーからのURLは、ブラウザ上部のアドレスと「共有」ボタンから得られる埋め込み用アドレスのどちらを入力してもいいようにpostモデルにID抽出メソッドを定義しました。


### 確認方法
テストはまだ書けていないので、ブラウザの挙動で確認をお願いします。
### `投稿一覧`
![image](https://user-images.githubusercontent.com/110599239/220659631-0d2ca66e-e156-48f8-b00d-6dd02caae54c.png)

### `投稿詳細（自分の投稿）`
![image](https://user-images.githubusercontent.com/110599239/220659856-be6c08f1-d469-41bc-a2fd-2e481fa1d873.png)

### `投稿詳細(他ユーザーの動画も閲覧可能)`
![image](https://user-images.githubusercontent.com/110599239/220660698-5e726ede-d915-4009-b920-0f30afcf193f.png)




### Issue
#40 