### PR TITLE
Slim-selectによるカテゴリ機能#109

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,13 +15,12 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    @post.build_category
     @default_tag = "#育児あるある"
   end
 
   def create
     @post = current_user.posts.build(post_params)
-    @post.category_id = params.dig(:post, :category, :category_id) # accepts_nested_attributes_forメソッドで保存できるまでの応急処置
+    binding.irb
     if @post.save_with_tags(tag_names: params.dig(:post, :tag_names).split(',').uniq)
       redirect_to @post, success: t('defaults.message.created', item: Post.model_name.human)
     else
@@ -42,7 +41,6 @@ class PostsController < ApplicationController
 
   def update
     @post.assign_attributes(post_params)
-    @post.category_id = params.dig(:post, :category, :category_id) # accepts_nested_attributes_forメソッドで保存できるまでの応急処置
     if @post.save_with_tags(tag_names: params.dig(:post, :tag_names).split(',').uniq)
       redirect_to @post, success: t('defaults.message.updated', item: Post.model_name.human)
     else
@@ -63,7 +61,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content, :embed_youtube, :image, categories_attributes: [:id])
+    params.require(:post).permit(:title, :content, :embed_youtube, :image, :category_id)
   end
 
   def set_post

--- a/app/javascript/controllers/slim_controller.js
+++ b/app/javascript/controllers/slim_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+// add the JS
+import SlimSelect from 'slim-select'
+// add the CSS
+// import 'slim-select/dist/slimselect.css'
+// import "slim-select/dist/slimselect.min.css";
+
+// Connects to data-controller="slim-select"
+export default class extends Controller {
+  static targets = ['field']
+  connect() {
+    new SlimSelect({
+      select: this.fieldTarget,
+      // closeOnSelect: false
+    })
+  }
+}

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,5 @@
 class Category < ApplicationRecord
   has_many :posts, inverse_of: :category
-  accepts_nested_attributes_for :posts
 
   validates :name, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <link href="https://unpkg.com/slim-select@latest/dist/slimselect.css" rel="stylesheet"/>
     <%= display_meta_tags(default_meta_tags) %>
   </head>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,9 +2,8 @@
     <%= form_with model: post, local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <div class="form-group mt-3">
-        <%= f.fields_for :category do |i| %>
-            <%= i.select :category_id, [["お風呂", 1], ["歯磨き", 2], ["お片付け", 3], ["食事", 4], ["着替え", 5],["お出かけ", 6]], class: "form-control" %>
-        <% end %>
+            <%= f.label :category_id %>
+            <%= f.select :category_id, Category.pluck(:name, :id), {include_blank: true}, {data: { controller: 'slim', slim_target: 'field' } } %>
         </div>
         <div class="form-group mt-3">
             <%= f.label :title %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -12,3 +12,4 @@ pin "@fortawesome/fontawesome-svg-core", to: "https://ga.jspm.io/npm:@fortawesom
 pin "@fortawesome/free-brands-svg-icons", to: "https://ga.jspm.io/npm:@fortawesome/free-brands-svg-icons@6.3.0/index.mjs"
 pin "@fortawesome/free-regular-svg-icons", to: "https://ga.jspm.io/npm:@fortawesome/free-regular-svg-icons@6.3.0/index.mjs"
 pin "@fortawesome/free-solid-svg-icons", to: "https://ga.jspm.io/npm:@fortawesome/free-solid-svg-icons@6.3.0/index.mjs"
+pin "slim-select", to: "https://ga.jspm.io/npm:slim-select@2.4.5/dist/slimselect.es.js"


### PR DESCRIPTION
### 内容
・slim-selectを使い、フォーム新規投稿時のカテゴリを選択しやすくしました。
・不要なfierlds_forを削除しリファクタリングしました。

### 確認方法
![image](https://user-images.githubusercontent.com/110599239/228285253-59555225-8afd-402b-bc7e-3ab8e469995a.png)


### Issue
#109 