### PR TITLE
MVPリリースフィードバック twitterシェア機能#84

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -38,4 +38,14 @@ class Post < ApplicationRecord
     false
   end
 
+  # twitterシェアボタン用のハッシュタグメソッドを定義
+  def hash_tags
+    return if self.tags.blank?
+    hash_tags = ""
+    self.tags.pluck(:name).each do |tag|
+      hash_tag = "%0A%23#{tag}"
+      hash_tags << hash_tag
+    end
+    return hash_tags
+  end
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -67,11 +67,15 @@
           </div>
         </li>
         <li class="list-inline-item float-end">
-          <%= link_to "https://twitter.com/intent/tweet?url=https://og.nullnull.dev/site/29da6d62-f206-afb0-3ceb-0f702c1f4abf&text=2歳児の【#{post.category.name}】を楽しくする工夫を投稿しました！%0A「#{post.title}」%0A%23育児あるある%0A", target: '_blank' do %>
+          <%= link_to "https://twitter.com/intent/tweet?url=https://og.nullnull.dev/site/29da6d62-f206-afb0-3ceb-0f702c1f4abf&text=2歳児の【#{post.category.name}】を楽しくする工夫をシェアしました！%0Aタイトルは「#{post.title}」です！%0A%23育児あるある#{post.hash_tags}%0A", target: '_blank' do %>
             <i class="fab fa-twitter fa-lg"></i>
           <% end %>
         </li>
     </div>
   </div>
 <% end %>
+
+
+
+
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -57,9 +57,21 @@
           <% end %>  
         </li>
       </ul>
-      <div data-turbo="false">
-        <%= render post.tags %>
-      </div>
+      <ul class="list-inline"></ul>
+        <li class="list-inline-item">
+          <p>タグ</p>
+        </li>
+        <li class="list-inline-item">
+          <div data-turbo="false">
+            <%= render post.tags %>
+          </div>
+        </li>
+        <li class="list-inline-item float-end">
+          <%= link_to "https://twitter.com/intent/tweet?url=https://og.nullnull.dev/site/29da6d62-f206-afb0-3ceb-0f702c1f4abf&text=2歳児の【#{post.category.name}】を楽しくする工夫を投稿しました！%0A「#{post.title}」%0A%23育児あるある%0A", target: '_blank' do %>
+            <i class="fab fa-twitter fa-lg"></i>
+          <% end %>
+        </li>
     </div>
   </div>
 <% end %>
+

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -52,6 +52,11 @@
                   <%= render @post.tags %>
                 </li>
                 <li class="list-inline-item"><%= l @post.created_at, format: :short %></li>
+                <li class="list-inline-item float-end">
+                  <%= link_to "https://twitter.com/intent/tweet?url=https://og.nullnull.dev/site/29da6d62-f206-afb0-3ceb-0f702c1f4abf&text=2歳児の【#{@post.category.name}】を楽しくする工夫をシェアしました！%0Aタイトルは「#{@post.title}」です！%0A%23育児あるある#{@post.hash_tags}%0A", target: '_blank' do %>
+                    <i class="fab fa-twitter fa-lg"></i>
+                  <% end %>
+                </li>
               </ul>
             
           </div>


### PR DESCRIPTION
### 内容
・一覧ページからそれぞれの投稿をtwitterで共有できるボタンを設置しました。
・投稿のタグをtwitterのハッシュタグとしたかったため、Postモデルにロジックを定義しました。
・詳細ページにもボタンを設置しました。


### 確認方法
```一覧ページ```
![image](https://user-images.githubusercontent.com/110599239/229369826-71064889-745d-4f5d-9afd-e7534089707a.png)

```詳細ページ```
![image](https://user-images.githubusercontent.com/110599239/229369935-a9ca33aa-1357-49ae-a789-9456ecc3aaef.png)

```twitter画面```
![image](https://user-images.githubusercontent.com/110599239/229370003-2b25d9e4-f784-4378-84ff-95965cf3d59b.png)
