### PR TITLE
Add:タグのキーワード補完 #107

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy]
-  before_action :set_popular_tags, only: %i[index most_liked most_bookmarked conprehensive]
+  before_action :set_popular_tags, only: %i[index most_liked most_bookmarked conprehensive create]
 
   def index
     posts = if(tag_name = params[:tag_name])
@@ -77,7 +77,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content, :embed_youtube, :image, :category_id)
+    params.require(:post).permit(:title, :content, :embed_youtube, :image, :category_id, tag_ids: [])
   end
 
   def set_post

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,17 +1,18 @@
 <div class="container">
     <%= form_with model: post, local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
+        <p><span style="color:red;">*</span>は必須項目です</p>
         <div class="form-group mt-3">
-            <%= f.label :category_id %>
+            <%= f.label :category_id, style: 'display:inline;' %><p style="display:inline; color:red;" >*</p>
             <%= f.select :category_id, Category.pluck(:name, :id), {include_blank: true}, {data: { controller: 'slim', slim_target: 'field' } } %>
         </div>
         <div class="form-group mt-3">
-            <%= f.label :title %>
+            <%= f.label :title, style: 'display:inline;' %><p style="display:inline; color:red;" >*</p>
             <%= f.text_field :title, class:'form-control'%>
         </div>
         <div class="form-group mt-3">
-            <%= f.label :content %>
-            <%= f.text_area :content, class: 'form-control', rows: 5 %>
+            <%= f.label :content, style: 'display:inline;' %><p style="display:inline; color:red;" >*</p>
+            <%= f.text_area :content, class: 'form-control', rows: 4 %>
         </div>
         <div class="form-group mt-3">
             <%= f.label :image %>
@@ -21,8 +22,12 @@
             <%= f.label :embed_youtube %>
             <%= f.text_field :embed_youtube, class: 'form-control' %>
         </div>
+        <div class="form-group mt-3">
+            <%= f.label :tags, 'タグを選択' %>
+            <%= f.select :tag_ids, Tag.all.pluck(:name, :id), {}, { multiple: true, data: { controller: 'slim', slim_target: 'field' } } %>
+        </div>
         <div class="mb-3 mt-3">
-            <%= f.label :tag_names, "タグ(任意) *複数タグを付ける場合はカンマ(,)で区切ってください" %>
+            <%= f.label :tag_names, "新しいタグを作成 *複数の場合はカンマ(,)で区切ってください" %>
             <%= f.text_field :tag_names, class: 'form-control', value: @tags %>
         </div>
         <div class="mb-3 mt-3">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <!-- turbo_frameリクエスト時のURL更新 -->
-<div class="container py-5">
+<div class="container py-3">
   <!-- post一覧-->
   <div class="row">
     <div class="col-12 col-lg-8">
@@ -17,7 +17,7 @@
     <!-- サイドのフォームと人気のタグ-->
       <div class="col-12 col-lg-4">
         <div class="sticky-top">
-          <div class="post-form-card">
+          <div class="post-form-card pt-2 pb-2">
             <div class="card-body m-3">
               <!-- indexページからの送信時turboはfalseにする -->
               <div id="post-form">
@@ -25,8 +25,8 @@
               </div>
             </div>
           </div>
-          <div class="d-flex justify-content-center">
-            <%= paginate @posts, theme: 'bootstrap-5' %>
+          <div class="d-flex justify-content-center pt-4">
+            <%= paginate @posts, theme: 'bootstrap-5' if !@post.present?%>
           </div>
           <div class="card my-4">
             <div class="card-header bg-primary text-white">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       post: '投稿'
       category: 'カテゴリ'
       comment: 'コメント'
+      tag: 'タグ'
       
     attributes: 
       user:
@@ -18,8 +19,9 @@ ja:
       post:
         title: 'タイトル'
         content: '内容'
-        embed_youtube: 'YouTube URL(任意)'
+        embed_youtube: 'YouTube動画埋め込み'
         created_at: '作成日時'
+        image: '画像'
       comment:
         body: 'コメント'
       category: 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -27,6 +27,9 @@ ja:
       most_liked: 'いいね順'
       most_bookmarked: 'ブックマーク順'
       comprehensive: '総合'
+    tag:
+      tags: 'タグを選択'
+      tag_names: '新しいタグを作成'
       
   users:
     new:
@@ -52,7 +55,6 @@ ja:
     index:
       title: 'みんなの投稿を見る'
       no_result: '投稿がありません。'
-      
     new:
       title: '投稿する'
     show:


### PR DESCRIPTION
### 内容
・Postの新規投稿時に既存のタグのキーワード補完を追加しました。
・フォームのビューを修正しました。

### 確認方法
![image](https://user-images.githubusercontent.com/110599239/230752578-5d881b53-e44d-49f4-ba25-86fa5b8b9a28.png)



### Issue
#107 